### PR TITLE
fix: override status bar

### DIFF
--- a/example/src/components/HeaderNavBar.tsx
+++ b/example/src/components/HeaderNavBar.tsx
@@ -1,15 +1,21 @@
 import { RoundButton } from './RoundButton';
-import { StyleSheet, View } from 'react-native';
+import { StatusBar, StyleSheet, View } from 'react-native';
 import * as React from 'react';
 import ArrowLeft from '../icons/ArrowLeft';
 import { ArrowRight } from '../icons/ArrowRight';
 import { Share } from '../icons/Share';
 import { useNavigation } from '@react-navigation/native';
+import { isIOS } from '../utils';
 
 export const HeaderNavBar = () => {
   const nav = useNavigation();
   return (
     <View style={styles.container}>
+      <StatusBar
+        translucent
+        barStyle={isIOS ? 'dark-content' : 'light-content'}
+        backgroundColor="black"
+      />
       <RoundButton icon={<ArrowLeft />} onPress={nav.goBack} />
       <View style={styles.btnRightContainer}>
         <View style={styles.btnRight}>

--- a/src/components/AnimatedHeader.tsx
+++ b/src/components/AnimatedHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StatusBar, StyleSheet, Animated } from 'react-native';
+import { StyleSheet, Animated } from 'react-native';
 import { useAnimateNavbar } from '../hooks/useAnimateNavbar';
 import type { AnimatedHeaderProps } from '../types';
 
@@ -18,11 +18,6 @@ const AnimatedHeader = ({
 
   return (
     <>
-      <StatusBar
-        barStyle={'dark-content'}
-        backgroundColor="transparent"
-        translucent
-      />
       <Animated.View
         style={[
           styles.container,


### PR DESCRIPTION
## Description
* Removed `<StatusBar/>` component from `AnimatedHeader.tsx.` 
By applying this change we can use `<StatusBar/>` with custom properties.
* Updated examples to show how `<StatusBar/>` can be used.

Fixes: https://github.com/kanelloc/react-native-animated-header-scroll-view/issues/18

## Type of change

<!--- Please delete options that are not relevant. --->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
