### PR TITLE
fix: bypass translations when disableScale is enabled

### DIFF
--- a/src/hooks/useAnimateScrollView.ts
+++ b/src/hooks/useAnimateScrollView.ts
@@ -34,7 +34,7 @@ export const useAnimateScrollView = (
     scroll,
     onScroll,
     disableScale ? 1 : scale,
-    translateYDown,
-    translateYUp,
+    disableScale ? 0 : translateYDown,
+    disableScale ? 0 : translateYUp,
   ] as const;
 };

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -63,8 +63,8 @@ export type AnimatedNavbarProps = {
 
 export type AnimatedHeaderProps = {
   imageHeight: number;
-  translateYUp: Animated.AnimatedInterpolation<string | number>;
-  translateYDown: Animated.AnimatedInterpolation<string | number>;
+  translateYUp: Animated.AnimatedInterpolation<string | number> | 0;
+  translateYDown: Animated.AnimatedInterpolation<string | number> | 0;
   scale: Animated.AnimatedInterpolation<string | number> | 1;
   imageStyle?: StyleProp<ImageStyle>;
   HeaderComponent?: JSX.Element;


### PR DESCRIPTION
## Description

* Bypass both up and down translations when `disableScale` prop is enabled

<!---Fixes # (issue) --->

## Type of change

<!--- Please delete options that are not relevant. --->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
